### PR TITLE
Enable case-sensitive cross compiling with MinGW

### DIFF
--- a/iup/external/src/win/iupwin_info.c
+++ b/iup/external/src/win/iupwin_info.c
@@ -19,7 +19,7 @@
 #include "iupwin_str.h"
 
 #include <windows.h>
-#include <ShlObj.h> /* for SHGetFolderPath */
+#include <shlobj.h> /* for SHGetFolderPath */
 
 
 #ifdef _MSC_VER


### PR DESCRIPTION
MinGW includes `shlobj.h` header in lowercase. Therefore if you are cross-compiling on a case-sensitive filesystem, the include must be lowercase.

This currently builts on linux when running
```
CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -v
```