### PR TITLE
Allow "nopkgconfig" build tag to disable cgo pkgconfig directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ On Linux, you need a C compiler and GTK+ development packages.
 When you are not using `gl` tag, the library is built with `GDK_NULL` to completely remove the [X11](https://en.wikipedia.org/wiki/X_Window_System) usage,
 so it should just work in [Wayland](https://en.wikipedia.org/wiki/Wayland_(display_server_protocol)).
 
+You may provide explicit compiler and linker flags instead of using the defaults provided by pkg-config, if `gtk3` and other dependencies are in a non-standard location:
+
+```
+CGO_CFLAGS="-I<include path> ..." CGO_LDFLAGS="-L<dir> -llib ..." go build -tags nopkconfig
+```  
+
 Note that you can also build and link against the GTK2 version, see build tags below.
 
 ![linux](examples/sample/sample_linux.png)
@@ -74,6 +80,7 @@ though not all controls and attributes are possible, check the documentation for
 * `gtk2` - link with GTK2 version, default is GTK3 (Linux)
 * `motif` - build for X11/Motif 2.x environment
 * `nomanifest` - do not include manifest in Windows build
+* `nopkgconfig` - do not use pkg-config for compile and link flags. User specifies CGO_CFLAGS and CGO_LDFLAGS env vars
 
 ### Documentation
 

--- a/iup/bind_cgo.go
+++ b/iup/bind_cgo.go
@@ -7,10 +7,10 @@ package iup
 #cgo !windows,!darwin,!motif,!gl CFLAGS: -Iexternal/src/gtk -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED -DGDK_NULL
 #cgo !windows,!darwin,motif CFLAGS: -Iexternal/src/mot
 
-#cgo !windows,!darwin,!motif,!gtk2,gl pkg-config: gtk+-3.0 gdk-3.0 gl
-#cgo !windows,!darwin,!motif,gtk2,gl pkg-config: gtk+-2.0 gdk-2.0 gl
-#cgo !windows,!darwin,!motif,!gtk2,!gl pkg-config: gtk+-3.0 gdk-3.0
-#cgo !windows,!darwin,!motif,gtk2,!gl pkg-config: gtk+-2.0 gdk-2.0
+#cgo !windows,!darwin,!motif,!gtk2,gl,!nopkgconfig pkg-config: gtk+-3.0 gdk-3.0 gl
+#cgo !windows,!darwin,!motif,gtk2,gl,!nopkgconfig pkg-config: gtk+-2.0 gdk-2.0 gl
+#cgo !windows,!darwin,!motif,!gtk2,!gl,!nopkgconfig pkg-config: gtk+-3.0 gdk-3.0
+#cgo !windows,!darwin,!motif,gtk2,!gl,!nopkgconfig pkg-config: gtk+-2.0 gdk-2.0
 
 #cgo !windows,!darwin,!motif,gl LDFLAGS: -lX11
 #cgo !windows,!darwin,!motif LDFLAGS: -lm
@@ -24,15 +24,15 @@ package iup
 #cgo windows CFLAGS: -D_WIN32_WINNT=0x0601 -DWINVER=0x0601 -DCOBJMACROS -DNOTREEVIEW -DUNICODE -D_UNICODE
 
 #cgo windows,gtk CFLAGS: -Iexternal/src/gtk -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED -DGDK_NULL
-#cgo windows,gtk pkg-config: gtk+-3.0 gdk-3.0
+#cgo windows,gtk,!nopkgconfig pkg-config: gtk+-3.0 gdk-3.0
 #cgo windows,gl LDFLAGS: -lgdi32 -lcomdlg32 -lcomctl32 -luuid -loleaut32 -lole32 -lopengl32
 #cgo windows,!gl LDFLAGS: -lgdi32 -lcomdlg32 -lcomctl32 -luuid -loleaut32 -lole32
 
-#cgo darwin,!gtk CFLAGS: -Iexternal/src/cocoa -x objective-c -mmacosx-version-min=10.14
+#cgo darwin,!gtk CFLAGS: -Iexternal/src/cocoa -x objective-c
 #cgo darwin,!gtk LDFLAGS: -framework SystemConfiguration -framework QuartzCore -framework Cocoa -mmacosx-version-min=10.14
 
-#cgo darwin,gtk CFLAGS: -Iexternal/src/gtk -x objective-c -mmacosx-version-min=10.14 -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED -DGDK_NULL -DGTK_MAC
-#cgo darwin,gtk pkg-config: gtk+-3.0 gdk-3.0
+#cgo darwin,gtk CFLAGS: -Iexternal/src/gtk -x objective-c -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED -DGDK_NULL -DGTK_MAC
+#cgo darwin,gtk,!nopkgconfig pkg-config: gtk+-3.0 gdk-3.0
 #cgo darwin,gtk LDFLAGS: -framework SystemConfiguration -framework QuartzCore -mmacosx-version-min=10.14
 */
 import "C"


### PR DESCRIPTION
I have a specific build environment where `libgtk-3-dev` and dependencies are in non-standard locations and I cannot rely on `pkg-config` to define the compiler and linker flags. My requirement is to be able to specify those flags directly, and for that to be possible a build tag needs to be able to disable the "pkgconfig" directive.

This MR allows the following, as an example, on linux:

```bash
export CGO_CFLAGS='\
    -I/usr/include/glib-2.0 \
    -I/usr/lib/x86_64-linux-gnu/glib-2.0/include \
    -I/custom/dir/libgtk-3-dev/usr/include/gtk-3.0 \
    -I/custom/dir/libgtk-3-dev/usr/include/pango-1.0 \
    -I/custom/dir/libgtk-3-dev/usr/include/cairo \
    -I/custom/dir/libgtk-3-dev/usr/include/gdk-pixbuf-2.0 \
    -I/custom/dir/libgtk-3-dev/usr/include/atk-1.0' 

export CGO_LDFLAGS='\
    -l:libgtk-3.so.0 -l:libgdk-3.so.0 -l:libpango-1.0.so.0 \
    -l:libpangocairo-1.0.so.0 -l:libcairo.so.2 -l:libgdk_pixbuf-2.0.so.0 \
    -l:libgobject-2.0.so.0 -l:libglib-2.0.so.0'

go build -tags nopkgconfig
```