### PR TITLE
Added include guard to core_iup_datepick.go

### DIFF
--- a/iup/core_iup_datepick.go
+++ b/iup/core_iup_datepick.go
@@ -1,6 +1,8 @@
 package iup
 
 /*
+#ifndef WIN32
 #include "external/src/iup_datepick.c"
+#endif
 */
 import "C"


### PR DESCRIPTION
Hey there,

I noticed that there are some platform-specific definitions for `IupDatePick` and `iupDatePickNewClass` that clash when cross-compiling from Linux to Windows. To fix this, I added an include guard in `core_iup_datepick.go` to stop the core implementation from being used when compiling for Windows.

This should take care of the build issues mentioned in:

#21 

I’ve compiled and tested it on both Linux and Windows, and everything seems to be working fine.

Thanks!